### PR TITLE
feat(input): add support for globbing matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Idea
+.idea/workspace.xml
+
 # Runtime data
 pids
 *.pid

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="BookmarkManager">
-    <bookmark url="file://$PROJECT_DIR$/src/replace.spec.js" line="61" />
-  </component>
   <component name="ChangeListManager">
-    <list default="true" id="e6328fb1-940d-4353-b179-5ba8a492f489" name="Default" comment="">
-      <change beforePath="$PROJECT_DIR$/src/cli.spec.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/cli.spec.js" afterDir="false" />
-    </list>
     <list id="40363042-f408-4464-b406-6a7ad506fce9" name="Revert &quot;fix(docs) positionals table&quot;" comment="Revert &quot;fix(docs) positionals table&quot;&#10;&#10;This reverts commit ffc5344" />
+    <list default="true" id="e6328fb1-940d-4353-b179-5ba8a492f489" name="Default" comment="feat(input): add support for globbing matching&#10;&#10;BREAKING CHANGE: api options rename: 'inputOptions' to 'inputReadOptions', 'outputOptions' to 'outputWriteOptions'&#10;BREAKING CHANGE: cli options rename: 'in-opts' to 'i-read-opts', 'out-opts' to 'o-write-opts'&#10;Add possibility to set input or output options through cli&#10;Docs&#10;Turn off camel-case-expansion to speed up yargs a bit&#10;&#10;fixes #3">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+    </list>
     <ignored path="$PROJECT_DIR$/.tmp/" />
     <ignored path="$PROJECT_DIR$/temp/" />
     <ignored path="$PROJECT_DIR$/tmp/" />
@@ -23,47 +21,38 @@
       <file leaf-file-name="replace.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/replace.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="255">
-              <caret line="15" column="19" selection-start-line="15" selection-start-column="19" selection-end-line="15" selection-end-column="19" />
+            <state relative-caret-position="289">
+              <caret line="38" column="57" lean-forward="true" selection-start-line="38" selection-start-column="57" selection-end-line="38" selection-end-column="57" />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="cli.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/cli.js">
+      <file leaf-file-name=".gitignore" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/.gitignore">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="-12">
-              <caret line="58" column="73" selection-start-line="58" selection-start-column="73" selection-end-line="58" selection-end-column="73" />
+            <state relative-caret-position="102">
+              <caret line="6" selection-start-line="6" selection-end-line="6" />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="cli.spec.js" pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/src/cli.spec.js">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="189">
-              <caret line="165" column="107" selection-start-line="165" selection-start-column="107" selection-end-line="165" selection-end-column="107" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="README.md" pinned="false" current-in-tab="false">
+      <file leaf-file-name="README.md" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/README.md">
           <provider selected="true" editor-type-id="split-provider[text-editor;markdown-preview-editor]">
             <state split_layout="SPLIT">
-              <first_editor relative-caret-position="373">
-                <caret line="73" column="123" selection-start-line="73" selection-start-column="123" selection-end-line="73" selection-end-column="123" />
+              <first_editor relative-caret-position="196">
+                <caret line="223" column="7" lean-forward="true" selection-start-line="223" selection-start-column="7" selection-end-line="223" selection-end-column="7" />
               </first_editor>
               <second_editor />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="package.json" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/package.json">
+      <file leaf-file-name="cli.spec.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/bin/cli.spec.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="131">
-              <caret line="24" column="33" selection-start-line="24" selection-start-column="33" selection-end-line="24" selection-end-column="33" />
+            <state relative-caret-position="149">
+              <caret line="160" column="24" selection-start-line="160" selection-start-column="19" selection-end-line="160" selection-end-column="24" />
             </state>
           </provider>
         </entry>
@@ -79,36 +68,36 @@
   </component>
   <component name="FindInProjectRecents">
     <findStrings>
-      <find>afterEach</find>
-      <find>runCli</find>
-      <find>tmpPrefix</find>
-      <find>a</find>
-      <find>async (ct)</find>
-      <find>async</find>
-      <find>async (t)</find>
-      <find>outputFileE</find>
-      <find>.input</find>
-      <find>tmpPRefix</find>
-      <find>.output</find>
-      <find>tmp(</find>
-      <find>tmp.fil</find>
-      <find>.file(</find>
-      <find>filename</find>
-      <find>tmpname</find>
-      <find>replaceFnPath</find>
-      <find>replaceFn</find>
-      <find>beforeEach</find>
-      <find>contentIndex</find>
-      <find>-</find>
-      <find>^\s*?(&amp;#8209;.*?)\s\s\s*?(.*?)\s*\[(.*)\]$</find>
-      <find>^\s*?(&amp;#8209;.*?)\s\s\s*(.*?)\s*\[(.*)\]$</find>
-      <find>^\s*?(&amp;#8209;.*?)\s\s*(.*?)\s*\[(.*)\]$</find>
-      <find>^\s*?(&amp;#8209;(?:(?:\S\s)|(?:\s\S)|(?:\S))*?)\s{3,}?(\S[\s\S]*?)\s{2,}\[(.+)\]$</find>
-      <find>nbsp</find>
-      <find>&quot;</find>
-      <find>output</find>
-      <find>input</find>
-      <find>readFileSync</find>
+      <find>this.loadingClass</find>
+      <find>onError</find>
+      <find>currentPageNo</find>
+      <find>console</find>
+      <find>.news-whole-prev</find>
+      <find>arra</find>
+      <find>top-menu-a</find>
+      <find>forEachElement</find>
+      <find>.top-menu-a</find>
+      <find>--</find>
+      <find>.top</find>
+      <find>keyframe</find>
+      <find>animation</find>
+      <find>top-header</find>
+      <find>hide</find>
+      <find>.nav-list</find>
+      <find>nav-list</find>
+      <find>closed</find>
+      <find>resize</find>
+      <find>opened</find>
+      <find>indexOf</find>
+      <find>submenuClass</find>
+      <find>getprodu</find>
+      <find>'id' =&gt; 0</find>
+      <find>ng-repeat</find>
+      <find>whole</find>
+      <find>top-menu-li</find>
+      <find>glob</find>
+      <find>join</find>
+      <find>array</find>
     </findStrings>
     <replaceStrings>
       <replace>checkSyncAsync</replace>
@@ -118,6 +107,14 @@
       <replace>&amp;#8209;</replace>
       <replace>| $1 | $3 | $2 |</replace>
       <replace>`</replace>
+      <replace>i-read-opts</replace>
+      <replace>o-write-opts</replace>
+      <replace>defaults.inputReadOptions</replace>
+      <replace>defaults.outputWriteOptions</replace>
+      <replace>keep: true, dir}</replace>
+      <replace>keep: true, dir,</replace>
+      <replace>tmpPrefixes.input</replace>
+      <replace>tmpPrefixes.output</replace>
     </replaceStrings>
   </component>
   <component name="Git.Settings">
@@ -142,10 +139,7 @@
     <option name="CHANGED_PATHS">
       <list>
         <option value="$PROJECT_DIR$/replace.js" />
-        <option value="$PROJECT_DIR$/src/elo.js" />
         <option value="$PROJECT_DIR$/node_modules/tap/lib/test.js" />
-        <option value="$PROJECT_DIR$/src/replace.js" />
-        <option value="$PROJECT_DIR$/src/replace.spec.js" />
         <option value="$PROJECT_DIR$/.travis.yml" />
         <option value="$PROJECT_DIR$/readme.txt" />
         <option value="$PROJECT_DIR$/../New folder/node_modules/frs-replace/index.js" />
@@ -155,9 +149,29 @@
         <option value="$PROJECT_DIR$/index.js" />
         <option value="$PROJECT_DIR$/../elo/elo.js" />
         <option value="$PROJECT_DIR$/src/cli.js" />
-        <option value="$PROJECT_DIR$/README.md" />
         <option value="$PROJECT_DIR$/package.json" />
         <option value="$PROJECT_DIR$/src/cli.spec.js" />
+        <option value="$PROJECT_DIR$/benchmarks/singleFile.bench.js" />
+        <option value="$PROJECT_DIR$/src/elo.js" />
+        <option value="$PROJECT_DIR$/src/replace.spec.js" />
+        <option value="$PROJECT_DIR$/bin/cli.spec.js" />
+        <option value="$PROJECT_DIR$/src/replace.js" />
+        <option value="$PROJECT_DIR$/src/perfy-tap.js" />
+        <option value="$PROJECT_DIR$/bin/cli.js" />
+        <option value="$PROJECT_DIR$/.gitignore" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/pliki/js/FRS-paginator.js" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/szablony/aktualnosci.php" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/szablony/_news.php" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/pliki/css/media-queries.css" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/pliki/css/main.css" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/szablony/_top.php" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/pliki/js/main.js" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/szablony/_top2.php" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/5/0/public_html/test+client/api/src/endpoints/products/DbKreatorDomuConnector.php" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/5/0/salsahouse/www/szablony/aktualnosci.php" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/5/0/salsahouse/www/pliki/css/main.css" />
+        <option value="$USER_HOME$/AppData/Local/Temp/_tcx/5/0/salsahouse/www/pliki/css/media-queries.css" />
+        <option value="$PROJECT_DIR$/README.md" />
       </list>
     </option>
   </component>
@@ -182,8 +196,8 @@
     </packageJsonPaths>
   </component>
   <component name="ProjectFrameBounds" extendedState="6">
-    <option name="x" value="-15" />
-    <option name="y" value="-15" />
+    <option name="x" value="35" />
+    <option name="y" value="15" />
     <option name="width" value="1845" />
     <option name="height" value="1105" />
   </component>
@@ -194,7 +208,6 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
-      <pane id="Scope" />
       <pane id="ProjectPane">
         <subPane>
           <expand>
@@ -205,16 +218,27 @@
             <path>
               <item name="FRS-replace" type="b2602c69:ProjectViewProjectNode" />
               <item name="FRS-replace" type="462c0819:PsiDirectoryNode" />
+              <item name="bin" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="FRS-replace" type="b2602c69:ProjectViewProjectNode" />
+              <item name="FRS-replace" type="462c0819:PsiDirectoryNode" />
+              <item name="coverage" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="FRS-replace" type="b2602c69:ProjectViewProjectNode" />
+              <item name="FRS-replace" type="462c0819:PsiDirectoryNode" />
               <item name="src" type="462c0819:PsiDirectoryNode" />
             </path>
           </expand>
           <select />
         </subPane>
       </pane>
+      <pane id="Scope" />
     </panes>
   </component>
   <component name="PropertiesComponent">
-    <property name="SearchEverywhereHistoryKey" value="package&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/package.json&#10;cli&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/src/cli.js&#10;packa&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/package.json&#10;index&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/index.js&#10;pack&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/package.json&#10;change&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/CHANGELOG.md" />
+    <property name="SearchEverywhereHistoryKey" value="cli.spec&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/bin/cli.spec.js&#10;readme&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/README.md&#10;.gitignore&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/.gitignore&#10;package&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/package.json&#10;cli&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/src/cli.js&#10;packa&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/package.json&#10;index&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/index.js&#10;pack&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/package.json&#10;change&#9;FILE&#9;file://D:/Projects/FRSSource/FRS-replace/CHANGELOG.md" />
     <property name="WebServerToolWindowFactoryState" value="false" />
     <property name="javascript.nodejs.core.library.configured.version" value="10.11.0" />
     <property name="last_opened_file_path" value="$PROJECT_DIR$" />
@@ -227,116 +251,6 @@
     <key name="MoveFile.RECENT_KEYS">
       <recent name="D:\Projects\FRSSource\FRS-replace\src" />
     </key>
-  </component>
-  <component name="RestoreUpdateTree" date="Moments ago" ActionInfo="_Update">
-    <UpdatedFiles>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Updated from server" />
-        <option name="myStatusName" value="Changed on server" />
-        <option name="mySupportsDeletion" value="false" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="CHANGED_ON_SERVER" />
-        <FILE-GROUP>
-          <option name="myUpdateName" value="Updated" />
-          <option name="myStatusName" value="Changed" />
-          <option name="mySupportsDeletion" value="false" />
-          <option name="myCanBeAbsent" value="false" />
-          <option name="myId" value="UPDATED" />
-          <PATH vcs="Git" revision="">$PROJECT_DIR$/README.md</PATH>
-        </FILE-GROUP>
-        <FILE-GROUP>
-          <option name="myUpdateName" value="Created" />
-          <option name="myStatusName" value="Created" />
-          <option name="mySupportsDeletion" value="false" />
-          <option name="myCanBeAbsent" value="false" />
-          <option name="myId" value="CREATED" />
-        </FILE-GROUP>
-        <FILE-GROUP>
-          <option name="myUpdateName" value="Deleted" />
-          <option name="myStatusName" value="Deleted" />
-          <option name="mySupportsDeletion" value="false" />
-          <option name="myCanBeAbsent" value="true" />
-          <option name="myId" value="REMOVED_FROM_REPOSITORY" />
-        </FILE-GROUP>
-        <FILE-GROUP>
-          <option name="myUpdateName" value="Restored" />
-          <option name="myStatusName" value="Will be restored" />
-          <option name="mySupportsDeletion" value="false" />
-          <option name="myCanBeAbsent" value="false" />
-          <option name="myId" value="RESTORED" />
-        </FILE-GROUP>
-      </FILE-GROUP>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Modified" />
-        <option name="myStatusName" value="Modified" />
-        <option name="mySupportsDeletion" value="false" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="MODIFIED" />
-      </FILE-GROUP>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Skipped" />
-        <option name="myStatusName" value="Skipped" />
-        <option name="mySupportsDeletion" value="false" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="SKIPPED" />
-      </FILE-GROUP>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Merged with conflicts" />
-        <option name="myStatusName" value="Will be merged with conflicts" />
-        <option name="mySupportsDeletion" value="false" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="MERGED_WITH_CONFLICTS" />
-      </FILE-GROUP>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Merged with tree conflicts" />
-        <option name="myStatusName" value="Merged with tree conflicts" />
-        <option name="mySupportsDeletion" value="false" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="MERGED_WITH_TREE_CONFLICT" />
-      </FILE-GROUP>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Merged with property conflicts" />
-        <option name="myStatusName" value="Will be merged with property conflicts" />
-        <option name="mySupportsDeletion" value="false" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="MERGED_WITH_PROPERTY_CONFLICT" />
-      </FILE-GROUP>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Merged" />
-        <option name="myStatusName" value="Will be merged" />
-        <option name="mySupportsDeletion" value="false" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="MERGED" />
-      </FILE-GROUP>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Not in repository" />
-        <option name="myStatusName" value="Not in repository" />
-        <option name="mySupportsDeletion" value="true" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="UNKNOWN" />
-      </FILE-GROUP>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Locally added" />
-        <option name="myStatusName" value="Locally added" />
-        <option name="mySupportsDeletion" value="false" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="LOCALLY_ADDED" />
-      </FILE-GROUP>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Locally removed" />
-        <option name="myStatusName" value="Locally removed" />
-        <option name="mySupportsDeletion" value="false" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="LOCALLY_REMOVED" />
-      </FILE-GROUP>
-      <FILE-GROUP>
-        <option name="myUpdateName" value="Switched" />
-        <option name="myStatusName" value="Switched" />
-        <option name="mySupportsDeletion" value="false" />
-        <option name="myCanBeAbsent" value="false" />
-        <option name="myId" value="SWITCHED" />
-      </FILE-GROUP>
-    </UpdatedFiles>
   </component>
   <component name="RunDashboard">
     <option name="ruleStates">
@@ -363,6 +277,14 @@
       <workItem from="1539295923296" duration="84813000" />
       <workItem from="1539603198517" duration="4435000" />
       <workItem from="1539720394864" duration="7422000" />
+      <workItem from="1540032532123" duration="34031000" />
+      <workItem from="1540239474193" duration="15258000" />
+      <workItem from="1540256288916" duration="580000" />
+      <workItem from="1540422410232" duration="776000" />
+      <workItem from="1540588438527" duration="4000" />
+      <workItem from="1540640218105" duration="702000" />
+      <workItem from="1540835446216" duration="922000" />
+      <workItem from="1541037786521" duration="2975000" />
     </task>
     <task id="LOCAL-00001" summary="Init commit&#10;    Package, CLI, tests, coverage, integration with travis, coveralls &amp; many more">
       <created>1539577933627</created>
@@ -441,17 +363,24 @@
       <option name="project" value="LOCAL" />
       <updated>1539734798020</updated>
     </task>
-    <option name="localTasksCounter" value="12" />
+    <task id="LOCAL-00012" summary="feat(input): add support for globbing matching&#10;&#10;BREAKING CHANGE: api options rename: 'inputOptions' to 'inputReadOptions', 'outputOptions' to 'outputWriteOptions'&#10;BREAKING CHANGE: cli options rename: 'in-opts' to 'i-read-opts', 'out-opts' to 'o-write-opts'&#10;Add possibility to set input or output options through cli&#10;Docs&#10;Turn off camel-case-expansion to speed up yargs a bit&#10;&#10;fixes #3">
+      <created>1540173977471</created>
+      <option name="number" value="00012" />
+      <option name="presentableId" value="LOCAL-00012" />
+      <option name="project" value="LOCAL" />
+      <updated>1540173977472</updated>
+    </task>
+    <option name="localTasksCounter" value="13" />
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="98026000" />
+    <option name="totallyTimeSpent" value="157301000" />
   </component>
   <component name="ToolWindowManager">
     <frame x="-7" y="-7" width="1472" height="878" extended-state="6" />
     <editor active="true" />
     <layout>
-      <window_info content_ui="combo" id="Project" order="0" visible="true" weight="0.24947736" />
+      <window_info content_ui="combo" id="Project" order="0" visible="true" weight="0.17421603" />
       <window_info anchor="bottom" id="TODO" order="6" />
       <window_info id="DB Browser" order="2" />
       <window_info anchor="bottom" id="Docker" order="7" show_stripe_button="false" />
@@ -460,38 +389,39 @@
       <window_info active="true" anchor="bottom" id="Version Control" order="7" sideWeight="0.49825785" visible="true" weight="0.4056604" />
       <window_info anchor="bottom" id="Run" order="2" />
       <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
-      <window_info anchor="bottom" id="Terminal" order="7" sideWeight="0.49965158" weight="0.24528302" />
+      <window_info anchor="bottom" id="Terminal" order="7" sideWeight="0.49965158" weight="0.31401616" />
       <window_info id="Favorites" order="2" side_tool="true" />
       <window_info anchor="bottom" id="Debug" order="3" weight="0.4" />
       <window_info anchor="right" content_ui="combo" id="Hierarchy" order="2" weight="0.25" />
       <window_info anchor="bottom" id="Inspection" order="5" weight="0.4" />
       <window_info anchor="right" id="Commander" internal_type="SLIDING" order="0" type="SLIDING" weight="0.4" />
       <window_info anchor="right" id="Ant Build" order="1" weight="0.25" />
+      <window_info anchor="bottom" id="Messages" order="7" weight="0.32884097" />
       <window_info anchor="bottom" id="Message" order="0" />
       <window_info anchor="bottom" id="Cvs" order="4" weight="0.25" />
       <window_info anchor="bottom" id="Find" order="1" />
-      <window_info anchor="bottom" id="Messages" order="7" weight="0.32884097" />
     </layout>
     <layout-to-restore>
-      <window_info anchor="bottom" id="DB Execution Console" order="0" />
+      <window_info anchor="bottom" id="DB Execution Console" order="8" />
       <window_info anchor="right" content_ui="combo" id="Hierarchy" order="2" weight="0.25" />
-      <window_info anchor="bottom" id="Docker" order="1" show_stripe_button="false" />
-      <window_info anchor="bottom" id="Version Control" order="2" />
-      <window_info content_ui="combo" id="Project" order="2" visible="true" weight="0.24947736" />
-      <window_info id="Structure" order="3" side_tool="true" weight="0.25" />
+      <window_info anchor="bottom" id="Docker" order="7" show_stripe_button="false" />
+      <window_info anchor="bottom" id="Version Control" order="11" sideWeight="0.49825785" weight="0.4056604" />
+      <window_info content_ui="combo" id="Project" order="0" visible="true" weight="0.17421603" />
+      <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
       <window_info anchor="right" id="Commander" internal_type="SLIDING" order="0" type="SLIDING" weight="0.4" />
       <window_info anchor="right" id="Ant Build" order="1" weight="0.25" />
-      <window_info anchor="bottom" id="TODO" order="11" />
-      <window_info anchor="bottom" id="Run" order="7" />
-      <window_info id="DB Browser" order="0" />
-      <window_info anchor="bottom" id="Debug" order="8" weight="0.4" />
-      <window_info anchor="bottom" id="Find" order="6" />
-      <window_info active="true" anchor="bottom" id="Terminal" order="3" visible="true" weight="0.32884097" />
-      <window_info anchor="bottom" id="Event Log" order="4" side_tool="true" />
-      <window_info anchor="bottom" id="Inspection" order="10" weight="0.4" />
-      <window_info anchor="bottom" id="Cvs" order="9" weight="0.25" />
-      <window_info anchor="bottom" id="Message" order="5" />
-      <window_info id="Favorites" order="1" side_tool="true" />
+      <window_info anchor="bottom" id="TODO" order="6" />
+      <window_info anchor="bottom" id="Run" order="2" />
+      <window_info id="DB Browser" order="2" />
+      <window_info anchor="bottom" id="Find" order="1" />
+      <window_info anchor="bottom" id="Debug" order="3" weight="0.4" />
+      <window_info active="true" anchor="bottom" id="Terminal" order="9" sideWeight="0.49965158" visible="true" weight="0.31401616" />
+      <window_info anchor="bottom" id="Event Log" order="10" sideWeight="0.5017422" side_tool="true" weight="0.4056604" />
+      <window_info anchor="bottom" id="Inspection" order="5" weight="0.4" />
+      <window_info anchor="bottom" id="Cvs" order="4" weight="0.25" />
+      <window_info anchor="bottom" id="Message" order="0" />
+      <window_info anchor="bottom" id="Messages" order="12" weight="0.32884097" />
+      <window_info id="Favorites" order="3" side_tool="true" />
     </layout-to-restore>
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -538,91 +468,15 @@
     <MESSAGE value="chore: upgrade, test running/release scripts&#10;&#10;Upgrade of npm dependencies&#10;Improvements for test running/release npm scripts" />
     <MESSAGE value="fix(docs) positionals table&#10;&#10;Positionals table doesn't show as it should (github's markdown has problems parsing it - there is probably some typo in there)&#10;&#10;fixes #6" />
     <MESSAGE value="feat(cli): Input &amp; output options&#10;&#10;Add possibility to set input or output options through cli&#10;Docs&#10;Turn off camel-case-expansion to speed up yargs a bit&#10;&#10;fixes #7" />
-    <option name="LAST_COMMIT_MESSAGE" value="feat(cli): Input &amp; output options&#10;&#10;Add possibility to set input or output options through cli&#10;Docs&#10;Turn off camel-case-expansion to speed up yargs a bit&#10;&#10;fixes #7" />
+    <MESSAGE value="feat(input): add support for globbing matching&#10;&#10;BREAKING CHANGE: api options rename: 'inputOptions' to 'inputReadOptions', 'outputOptions' to 'outputWriteOptions'&#10;BREAKING CHANGE: cli options rename: 'in-opts' to 'i-read-opts', 'out-opts' to 'o-write-opts'&#10;Add possibility to set input or output options through cli&#10;Docs&#10;Turn off camel-case-expansion to speed up yargs a bit&#10;&#10;fixes #3" />
+    <option name="LAST_COMMIT_MESSAGE" value="feat(input): add support for globbing matching&#10;&#10;BREAKING CHANGE: api options rename: 'inputOptions' to 'inputReadOptions', 'outputOptions' to 'outputWriteOptions'&#10;BREAKING CHANGE: cli options rename: 'in-opts' to 'i-read-opts', 'out-opts' to 'o-write-opts'&#10;Add possibility to set input or output options through cli&#10;Docs&#10;Turn off camel-case-expansion to speed up yargs a bit&#10;&#10;fixes #3" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>
-      <option name="time" value="1" />
+      <option name="time" value="8" />
     </breakpoint-manager>
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/src/replace.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="170">
-          <caret line="10" lean-forward="true" selection-start-line="10" selection-end-line="10" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/README.md">
-      <provider selected="true" editor-type-id="split-provider[text-editor;markdown-preview-editor]">
-        <state split_layout="SPLIT">
-          <first_editor relative-caret-position="85">
-            <caret line="5" column="98" lean-forward="true" selection-start-line="5" selection-start-column="98" selection-end-line="5" selection-end-column="98" />
-          </first_editor>
-          <second_editor />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/cli.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state>
-          <caret column="19" lean-forward="true" selection-start-column="19" selection-end-column="19" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/cli.spec.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="3349">
-          <caret line="197" column="27" selection-start-line="197" selection-start-column="27" selection-end-line="197" selection-end-column="27" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/package.json">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="391">
-          <caret line="23" column="33" lean-forward="true" selection-start-line="23" selection-start-column="33" selection-end-line="23" selection-end-column="33" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/node_modules/yargs/index.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="170">
-          <caret line="10" column="3" selection-start-line="10" selection-start-column="3" selection-end-line="10" selection-end-column="3" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/node_modules/yargs/yargs.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="168">
-          <caret line="234" column="4" selection-start-line="234" selection-start-column="4" selection-end-line="234" selection-end-column="4" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/elo.js" />
-    <entry file="file://$PROJECT_DIR$/node_modules/tap/lib/test.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="168">
-          <caret line="1280" column="10" selection-start-line="1280" selection-start-column="10" selection-end-line="1280" selection-end-column="10" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/.test_tmp/cli.replace.js" />
-    <entry file="file://$PROJECT_DIR$/src/replace.spec.js" />
-    <entry file="file://$PROJECT_DIR$/.travis.yml" />
-    <entry file="file://$PROJECT_DIR$/index.js" />
-    <entry file="file://$PROJECT_DIR$/readme.txt" />
-    <entry file="file://$PROJECT_DIR$/CHANGELOG.md" />
-    <entry file="file://$PROJECT_DIR$/package.json" />
-    <entry file="file://$PROJECT_DIR$/src/replace.js" />
-    <entry file="file://$PROJECT_DIR$/src/cli.js" />
-    <entry file="file://$PROJECT_DIR$/src/cli.spec.js" />
-    <entry file="file://$PROJECT_DIR$/LICENSE">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="136">
-          <caret line="8" column="10" lean-forward="true" selection-start-line="8" selection-start-column="10" selection-end-line="8" selection-end-column="10" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/README.md">
       <provider selected="true" editor-type-id="split-provider[text-editor;markdown-preview-editor]">
         <state split_layout="SPLIT">
@@ -646,35 +500,13 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/elo.js" />
-    <entry file="file://$PROJECT_DIR$/node_modules/tap/lib/test.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="168">
-          <caret line="1280" column="10" selection-start-line="1280" selection-start-column="10" selection-end-line="1280" selection-end-column="10" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/.test_tmp/cli.replace.js" />
-    <entry file="file://$PROJECT_DIR$/.travis.yml">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="51">
-          <caret line="3" column="10" selection-start-line="3" selection-start-column="10" selection-end-line="3" selection-end-column="10" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/readme.txt" />
     <entry file="file://$PROJECT_DIR$/../New folder/node_modules/frs-replace/src/replace.js" />
     <entry file="file://$PROJECT_DIR$/../New folder/node_modules/frs-replace/index.js" />
     <entry file="file://$PROJECT_DIR$/../elo/package.json" />
     <entry file="file://$PROJECT_DIR$/../elo/node_modules/frs-replace/README.md" />
     <entry file="file://$PROJECT_DIR$/../elo/node_modules/frs-replace/index.js" />
-    <entry file="file://$PROJECT_DIR$/index.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="17">
-          <caret line="1" selection-start-line="1" selection-end-line="1" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/../elo/elo.js" />
     <entry file="file://$PROJECT_DIR$/../README.md">
       <provider selected="true" editor-type-id="split-provider[text-editor;markdown-preview-editor]">
@@ -686,48 +518,170 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/replace.spec.js">
+    <entry file="file://$PROJECT_DIR$/src/cli.js" />
+    <entry file="file://$PROJECT_DIR$/src/cli.spec.js" />
+    <entry file="file://$PROJECT_DIR$/.travis.yml">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="391">
-          <caret line="23" selection-start-line="23" selection-end-line="23" />
+        <state relative-caret-position="34">
+          <caret line="2" column="10" lean-forward="true" selection-start-line="2" selection-start-column="10" selection-end-line="2" selection-end-column="10" />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/cli.js">
+    <entry file="file://$PROJECT_DIR$/coverage/lcov.info">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/index.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-12">
-          <caret line="58" column="73" selection-start-line="58" selection-start-column="73" selection-end-line="58" selection-end-column="73" />
+        <state relative-caret-position="17">
+          <caret line="1" selection-start-line="1" selection-end-line="1" />
         </state>
       </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/node_modules/benchmark/benchmark.js" />
+    <entry file="file://$PROJECT_DIR$/benchmarks/singleFile.bench.js" />
+    <entry file="file://$PROJECT_DIR$/node_modules/function-loop/index.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="272">
+          <caret line="34" column="24" lean-forward="true" selection-start-line="34" selection-start-column="24" selection-end-line="34" selection-end-column="24" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/node_modules/tap/lib/test.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="168">
+          <caret line="201" column="16" selection-start-line="201" selection-start-column="16" selection-end-line="201" selection-end-column="16" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/node_modules/@mrmlnc/readdir-enhanced/lib/directory-reader.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="161">
+          <caret line="77" column="9" selection-start-line="77" selection-start-column="9" selection-end-line="77" selection-end-column="9" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/perfy-tap.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="255">
+          <caret line="15" column="38" selection-start-line="15" selection-start-column="38" selection-end-line="15" selection-end-column="38" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/elo.js" />
+    <entry file="file://$PROJECT_DIR$/src/replace.spec.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="1275">
+          <caret line="75" column="28" selection-start-line="75" selection-start-column="28" selection-end-line="75" selection-end-column="28" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/.gitignore">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="102">
+          <caret line="6" selection-start-line="6" selection-end-line="6" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/pliki/js/FRS-table.js" />
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/pliki/js/news.js" />
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/pliki/js/FRS-paginator.js" />
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/szablony/aktualnosci.php" />
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/szablony/_news.php" />
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/pliki/css/media-queries.css">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="2210">
+          <caret line="130" column="9" selection-start-line="130" selection-start-column="9" selection-end-line="130" selection-end-column="9" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/pliki/css/main.css" />
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/pliki/js/main.js" />
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/szablony/_top2.php" />
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/2/0/salsahouse/www/szablony/_top.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="144">
+          <caret line="44" column="11" lean-forward="true" selection-start-line="44" selection-start-column="11" selection-end-line="54" selection-end-column="11" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/5/0/public_html/api/src/endpoints/products/DbProductConnector.php" />
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/5/0/public_html/api/src/endpoints/products/DbNokautConnector.php" />
+    <entry file="file://$PROJECT_DIR$/package.json">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="660">
+          <caret line="45" column="4" lean-forward="true" selection-start-line="45" selection-start-column="4" selection-end-line="45" selection-end-column="4" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/bin/cli.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="660">
+          <caret line="53" column="13" selection-start-line="53" selection-start-column="13" selection-end-line="53" selection-end-column="23" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/Documents/kalkulatorremontowy/app/html/admin/property/property.tpl.html">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="249">
+          <caret line="108" column="27" selection-start-line="108" selection-start-column="18" selection-end-line="108" selection-end-column="27" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/Documents/kalkulatorremontowy/api/src/endpoints/products/DbKreatorDomuConnector.php">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/5/0/public_html/test+client/api/src/endpoints/products/DbKreatorDomuConnector.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="329">
+          <caret line="268" column="15" lean-forward="true" selection-start-line="268" selection-start-column="15" selection-end-line="268" selection-end-column="15" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/5/0/salsahouse/www/pliki/css/media-queries.css">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="460">
+          <caret line="80" column="27" selection-start-line="80" selection-start-column="27" selection-end-line="80" selection-end-column="27" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/5/0/salsahouse/www/pliki/css/main.css">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="622">
+          <caret line="489" column="11" selection-start-line="489" selection-start-column="11" selection-end-line="489" selection-end-column="11" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/AppData/Local/Temp/_tcx/5/0/salsahouse/www/szablony/aktualnosci.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="476">
+          <caret line="47" column="46" selection-start-line="47" selection-start-column="46" selection-end-line="47" selection-end-column="46" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$USER_HOME$/Documents/kalkulatorremontowy/api/src/endpoints/products/DbNokautConnector.php">
+      <provider selected="true" editor-type-id="text-editor" />
     </entry>
     <entry file="file://$PROJECT_DIR$/src/replace.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="255">
-          <caret line="15" column="19" selection-start-line="15" selection-start-column="19" selection-end-line="15" selection-end-column="19" />
+        <state relative-caret-position="289">
+          <caret line="38" column="57" lean-forward="true" selection-start-line="38" selection-start-column="57" selection-end-line="38" selection-end-column="57" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/bin/cli.spec.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="149">
+          <caret line="160" column="24" selection-start-line="160" selection-start-column="19" selection-end-line="160" selection-end-column="24" />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/README.md">
       <provider selected="true" editor-type-id="split-provider[text-editor;markdown-preview-editor]">
         <state split_layout="SPLIT">
-          <first_editor relative-caret-position="373">
-            <caret line="73" column="123" selection-start-line="73" selection-start-column="123" selection-end-line="73" selection-end-column="123" />
+          <first_editor relative-caret-position="196">
+            <caret line="223" column="7" lean-forward="true" selection-start-line="223" selection-start-column="7" selection-end-line="223" selection-end-column="7" />
           </first_editor>
           <second_editor />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/package.json">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="131">
-          <caret line="24" column="33" selection-start-line="24" selection-start-column="33" selection-end-line="24" selection-end-column="33" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/cli.spec.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="189">
-          <caret line="165" column="107" selection-start-line="165" selection-start-column="107" selection-end-line="165" selection-end-column="107" />
         </state>
       </provider>
     </entry>

--- a/package.json
+++ b/package.json
@@ -55,12 +55,14 @@
     "camel-case-expansion": false
   },
   "devDependencies": {
+    "replace": "^1.0.0",
     "standard": "^12.0.1",
     "standard-version": "^4.4.0",
     "tap": "^12.0.1",
     "tmp-promise": "^1.0.5"
   },
   "dependencies": {
+    "fast-glob": "^2.2.3",
     "get-stdin": "^6.0.0",
     "write": "^1.0.3",
     "yargs": "^12.0.2"

--- a/src/perfy-tap.js
+++ b/src/perfy-tap.js
@@ -1,0 +1,20 @@
+const perfy = require('perfy')
+
+module.exports = function (_tap) {
+  _tap.sub = subWrapper.bind(_tap, _tap.sub)
+  _tap.Test.prototype.sub = subWrapper.bind(_tap, _tap.Test.prototype.sub)
+
+  //
+
+  function subWrapper (originalSub, Class, extra) {
+    var args = Array.prototype.slice.call(arguments, 1)
+    const name = extra.name
+    perfy.start(name)
+
+    const promise = originalSub.apply(this, args)
+
+    promise.then(() => perfy.end(extra.name))
+
+    return promise
+  }
+}

--- a/src/replace.js
+++ b/src/replace.js
@@ -15,31 +15,37 @@ module.exports = {
 
 function replace ({
   input = void 0,
-  inputOptions = 'utf8',
+  inputReadOptions = 'utf8',
+  inputGlobOptions = void 0,
+  inputJoinString = '\n',
   content = void 0,
   regex,
   replacement,
   output = void 0,
-  outputOptions = 'utf8'
+  outputWriteOptions = 'utf8'
 }) {
   if (!input && !content) {
     writeError('at least one input source must be defined!')
   }
 
-  let path
+  let result
 
-  if (!content) {
-    content = require('fs').readFileSync((path = require('path')).normalize(input), inputOptions)
+  if (content) {
+    result = content.replace(regex, replacement)
+  } else {
+    const fs = require('fs')
+    result = require('fast-glob')
+      .sync(input, inputGlobOptions)
+      .map((path) => fs.readFileSync(path, inputReadOptions).replace(regex, replacement))
+      .join(inputJoinString)
   }
 
-  const result = content.replace(regex, replacement)
-
   if (output) {
-    if (typeof outputOptions === 'string') {
-      outputOptions = { encoding: outputOptions }
+    if (typeof outputWriteOptions === 'string') {
+      outputWriteOptions = { encoding: outputWriteOptions }
     }
 
-    require('write').sync((path || require('path')).normalize(output), result, outputOptions)
+    require('write').sync(require('path').normalize(output), result, outputWriteOptions)
   }
 
   return result

--- a/src/replace.spec.js
+++ b/src/replace.spec.js
@@ -1,23 +1,42 @@
 const tap = require('tap')
 const tmp = require('tmp-promise')
 const fs = require('fs')
+const path = require('path')
+const glob = require('fast-glob')
+
 const replace = require('./replace')
 
-const tmpPrefix = 'FRS-replace-replace'
-const content = `aąbcć
-deęfg%hi
+const tmpPrefixes = {
+  input: 'FRS-replace-replace-in',
+  output: 'FRS-replace-replace-out'
+}
+const content = `aąbcćdeęfg%hi
 jklmn
-oópqr,stuvw
-xyZ`
+oópqr,stuvwxyZ`
 const regex = new RegExp('^[adjox]', 'gm')
 const replacement = 'ą|'
 const replaceFn = () => replacement
-const defaultEncoding = 'utf8'
-let input, output
+const defaults = {
+  inputReadOptions: 'utf8',
+  outputWriteOptions: 'utf8',
+  inputJoinString: '\n'
+}
+let output, dir
+
+{
+  const dirObj = tmp.dirSync() // removing all files similar our tmp
+  dir = dirObj.name
+
+  glob.sync(
+    [
+      path.join(dir, tmpPrefixes.input),
+      path.join(dir, tmpPrefixes.output)
+    ].map(v => v + '*')
+  )
+    .forEach(fs.unlinkSync)
+}
 
 tap.afterEach((done) => {
-  input && input.cleanup()
-  input = void 0
   fs.existsSync(output) && fs.unlinkSync(output)
   done()
 })
@@ -51,24 +70,95 @@ tap.test('check api', async t => {
     ct.end()
   })
 
-  await tmp.file({ prefix: tmpPrefix, keep: true }).then(
-    async f => {
-      input = f
-      return new Promise(
-        (resolve) => fs.appendFile(f.path, content, { encoding: defaultEncoding }, resolve)
-      )
+  await t.test('input', async ct => {
+    let input, input2
+
+    const cleanInputs = (done) => {
+      input2 && input2.cleanup()
+      input2 = void 0
+      input && input.cleanup()
+      input = void 0
+      done && done() // to be runned either by node-tap or manually
+    }
+
+    ct.beforeEach(async () => {
+      cleanInputs()
+
+      await tmp.file({ prefix: tmpPrefixes.input, keep: true, dir })
+        .then(
+          async f => {
+            input = f
+            return new Promise(
+              (resolve) => fs.appendFile(f.path, content, { encoding: defaults.inputReadOptions }, resolve)
+            )
+          })
+      await tmp.file({ prefix: tmpPrefixes.input, keep: true, dir })
+        .then(
+          async f => {
+            input2 = f
+            return new Promise(
+              (resolve) => fs.appendFile(f.path, content, { encoding: defaults.inputReadOptions }, resolve)
+            )
+          })
     })
 
-  await t.test('input', async ct => {
-    testInput.input = input.path
-    await checkSyncAsync(ct, 'is', [testInput, expectedOutput, 'replaced correctly'])
+    ct.afterEach(cleanInputs)
+
+    await ct.test('as single file path', async cct => {
+      testInput.input = input.path
+      await checkSyncAsync(cct, 'is', [testInput, expectedOutput, 'replaced correctly'])
+
+      await cct.test('with inputReadOptions as object', async ccct => {
+        testInput.input = input.path
+        testInput.inputReadOptions = { encoding: defaults.inputReadOptions }
+
+        await checkSyncAsync(ccct, 'is', [testInput, expectedOutput, 'replaced correctly'])
+
+        ccct.end()
+      })
+
+      cct.end()
+    })
+
+    await ct.test('as array of file paths', async cct => {
+      testInput.input = [input.path, input2.path]
+      await checkSyncAsync(cct, 'is', [testInput, expectedOutput + defaults.inputJoinString + expectedOutput, 'replaced correctly'])
+
+      await cct.test('with inputJoinString changed', async ccct => {
+        testInput.input = `${dir}\\${tmpPrefixes.input}*`
+        testInput.inputJoinString = 'someCustomString\n\t'
+
+        await checkSyncAsync(ccct, 'is', [testInput, expectedOutput + testInput.inputJoinString + expectedOutput, 'replaced correctly'])
+
+        ccct.end()
+      })
+
+      cct.end()
+    })
+
+    await ct.test('as glob pattern', async cct => {
+      testInput.input = `${dir}\\${tmpPrefixes.input}*`
+
+      await checkSyncAsync(cct, 'is', [testInput, expectedOutput + defaults.inputJoinString + expectedOutput, 'replaced correctly'])
+
+      await cct.test('with inputGlobOptions', async ccct => {
+        testInput.input = `${dir}\\${tmpPrefixes.input}*`
+        testInput.inputGlobOptions = { onlyDirectories: true }
+
+        await checkSyncAsync(ccct, 'is', [testInput, '', 'replaced correctly'])
+
+        ccct.end()
+      })
+
+      cct.end()
+    })
 
     ct.end()
   })
 
   await t.test('output', async ct => {
     testInput.content = content
-    output = testInput.output = tmp.tmpNameSync({ prefix: tmpPrefix })
+    output = testInput.output = tmp.tmpNameSync({ prefix: tmpPrefixes.output, dir })
 
     await checkSyncAsync(ct, 'is', [testInput, expectedOutput, 'replaced correctly'])
 
@@ -82,8 +172,8 @@ tap.test('check api', async t => {
 
   await t.test('outputOptions as object', async ct => {
     testInput.content = content
-    output = testInput.output = tmp.tmpNameSync({ prefix: tmpPrefix })
-    testInput.outputOptions = { encoding: defaultEncoding }
+    output = testInput.output = tmp.tmpNameSync({ prefix: tmpPrefixes.output, dir })
+    testInput.outputOptions = { encoding: defaults.outputWriteOptions }
 
     await checkSyncAsync(ct, 'is', [testInput, expectedOutput, 'replaced correctly'])
 
@@ -99,7 +189,7 @@ tap.test('check api', async t => {
     expectedOutput = content.replace(regex, replaceFn)
 
     testInput.content = content
-    output = testInput.output = tmp.tmpNameSync({ prefix: tmpPrefix })
+    output = testInput.output = tmp.tmpNameSync({ prefix: tmpPrefixes.output, dir })
     testInput.replacement = replaceFn
 
     await checkSyncAsync(ct, 'is', [testInput, expectedOutput, 'replaced correctly'])

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@mrmlnc/readdir-enhanced@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
+  dependencies:
+    call-me-maybe "^1.0.1"
+    glob-to-regexp "^0.3.0"
+
+"@nodelib/fs.stat@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz#54c5a964462be3d4d78af631363c18d6fa91ac26"
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -62,6 +73,10 @@ ansi-styles@^3.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -331,6 +346,10 @@ caching-transform@^1.0.0:
     mkdirp "^0.5.1"
     write-file-atomic "^1.1.4"
 
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -385,6 +404,14 @@ chalk@^2.0.0, chalk@^2.1.0:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -461,6 +488,10 @@ color-name@1.1.3:
 color-support@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
+
+colors@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.4.tgz#e0cb41d3e4b20806b3bfc27f4559f01b94bc2f7c"
 
 combined-stream@1.0.6:
   version "1.0.6"
@@ -1170,6 +1201,17 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
+fast-glob@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.3.tgz#d09d378e9ef6b0076a0fa1ba7519d9d4d9699c28"
+  dependencies:
+    "@mrmlnc/readdir-enhanced" "^2.2.1"
+    "@nodelib/fs.stat" "^1.0.1"
+    glob-parent "^3.1.0"
+    is-glob "^4.0.0"
+    merge2 "^1.2.1"
+    micromatch "^3.1.10"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -1401,6 +1443,17 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
@@ -1465,6 +1518,10 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
 
 has-flag@^1.0.0:
   version "1.0.0"
@@ -1684,6 +1741,10 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
+is-extglob@^2.1.0, is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
@@ -1705,6 +1766,18 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
+
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  dependencies:
+    is-extglob "^2.1.0"
+
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -2158,6 +2231,10 @@ merge-source-map@^1.1.0:
   dependencies:
     source-map "^0.6.1"
 
+merge2@^1.2.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
+
 micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -2208,7 +2285,7 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -2292,6 +2369,13 @@ natural-compare@^1.4.0:
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+
+nomnom@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
 
 normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
   version "2.4.0"
@@ -2534,6 +2618,10 @@ parse-json@^4.0.0:
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -2800,6 +2888,14 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+replace@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace/-/replace-1.0.0.tgz#da5235cc6d64d5c3a74e4ef73b487aad0f79a74b"
+  dependencies:
+    colors "1.2.4"
+    minimatch "3.0.4"
+    nomnom "1.8.1"
 
 request@^2.85.0:
   version "2.88.0"
@@ -3161,6 +3257,10 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -3415,6 +3515,10 @@ uglify-js@^3.1.4:
   dependencies:
     commander "~2.17.1"
     source-map "~0.6.1"
+
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 unicode-length@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
BREAKING CHANGE: api options rename: 'inputOptions' to 'inputReadOptions', 'outputOptions' to 'outputWriteOptions'
BREAKING CHANGE: cli options rename: 'in-opts' to 'i-read-opts', 'out-opts' to 'o-write-opts'
Add possibility to set input or output options through cli
Docs - fixes & new example
Turn off camel-case-expansion to speed up yargs a bit

fixes #3